### PR TITLE
Remove needless nil in condition

### DIFF
--- a/zimports.el
+++ b/zimports.el
@@ -79,7 +79,7 @@ Show zimports output, if zimports exit abnormally and DISPLAY is t."
       (with-current-buffer buf
         (erase-buffer)))
     (condition-case err
-        (if (and (not (zerop (zimports-call-bin original-buffer tmpbuf errbuf))) nil)
+        (if (not (zerop (zimports-call-bin original-buffer tmpbuf errbuf)))
             (error "Process zimports failed, see %s buffer for details" (buffer-name errbuf))
           (unless (or (eq (buffer-size tmpbuf) 0) (eq (compare-buffer-substrings tmpbuf nil nil original-buffer nil nil) 0))
             (with-current-buffer original-buffer (replace-buffer-contents tmpbuf)))


### PR DESCRIPTION
This also fixes following byte-compile warnings

```
zimports.el:72:22:Warning: value returned from (= (zimports-call-bin
    original-buffer tmpbuf errbuf) 0) is unused
zimports.el:72:22:Warning: value returned from (= (zimports-call-bin
    original-buffer tmpbuf errbuf) 0) is unused
```